### PR TITLE
[Feat] Spring AOP 인가 로직 구현

### DIFF
--- a/src/main/java/com/forfour/domain/member/entity/Role.java
+++ b/src/main/java/com/forfour/domain/member/entity/Role.java
@@ -1,0 +1,6 @@
+package com.forfour.domain.member.entity;
+
+public enum Role {
+    MEMBER,
+    ADMIN
+}

--- a/src/main/java/com/forfour/global/auth/annotations/AuthGuard.java
+++ b/src/main/java/com/forfour/global/auth/annotations/AuthGuard.java
@@ -1,0 +1,14 @@
+package com.forfour.global.auth.annotations;
+
+import com.forfour.global.auth.guards.Authorizable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthGuard {
+    Class<? extends Authorizable>[] value();
+}

--- a/src/main/java/com/forfour/global/auth/aspect/AuthGuardAspect.java
+++ b/src/main/java/com/forfour/global/auth/aspect/AuthGuardAspect.java
@@ -1,0 +1,62 @@
+package com.forfour.global.auth.aspect;
+
+import com.forfour.domain.member.entity.Role;
+import com.forfour.global.auth.annotations.AuthGuard;
+import com.forfour.global.auth.context.MemberContext;
+import com.forfour.global.auth.guards.Authorizable;
+import com.forfour.global.jwt.dto.JwtTokenClaimsDto;
+import com.forfour.global.jwt.exception.AuthorizationException;
+import com.forfour.global.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthGuardAspect {
+
+    private final ApplicationContext applicationContext;
+    private final JwtService jwtService;
+
+    @Around("@annotation(authGuard)")
+    public Object applyGuards(ProceedingJoinPoint joinPoint, AuthGuard authGuard) throws Throwable {
+        // 토큰 추출
+        HttpServletRequest httpServletRequest = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String token = jwtService.extractJwtToken(httpServletRequest);
+        jwtService.isValidToken(token);
+        JwtTokenClaimsDto memberClaims = jwtService.extractJwtToken(token);
+
+
+        // 인가 검증 후 Context 저장
+        authorize(authGuard.value(), memberClaims.role());
+        MemberContext.setCurrentMemberClaims(memberClaims);
+
+        // 본문 실행
+        Object proceed = joinPoint.proceed();
+
+        // Context Clear
+        MemberContext.clear();
+
+        return proceed;
+    }
+
+    public void authorize(Class<? extends Authorizable>[] authGuards, Role tokenRole) {
+        boolean isAuthorized = Arrays.stream(authGuards)
+                .map(applicationContext::getBean)
+                .anyMatch(guard -> guard.isAuthorized(tokenRole));
+
+        if (!isAuthorized) {
+            throw new AuthorizationException();
+        }
+    }
+
+}

--- a/src/main/java/com/forfour/global/auth/context/MemberContext.java
+++ b/src/main/java/com/forfour/global/auth/context/MemberContext.java
@@ -1,0 +1,22 @@
+package com.forfour.global.auth.context;
+
+
+import com.forfour.global.jwt.dto.JwtTokenClaimsDto;
+
+public class MemberContext {
+
+    private static final ThreadLocal<JwtTokenClaimsDto> currentMemberContext = new ThreadLocal<JwtTokenClaimsDto>();
+
+    public static void setCurrentMemberClaims(JwtTokenClaimsDto memberClaims) {
+        currentMemberContext.set(memberClaims);
+    }
+
+    public static void clear() {
+        currentMemberContext.remove();
+    }
+
+    public static Long getMemberId() {
+        return currentMemberContext.get().memberId();
+    }
+
+}

--- a/src/main/java/com/forfour/global/auth/guards/AdminGuard.java
+++ b/src/main/java/com/forfour/global/auth/guards/AdminGuard.java
@@ -1,0 +1,17 @@
+package com.forfour.global.auth.guards;
+
+import com.forfour.domain.member.entity.Role;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminGuard extends Guard implements Authorizable {
+
+    public AdminGuard() {
+        super(Role.ADMIN);
+    }
+
+    @Override
+    public boolean isAuthorized(Role role) {
+        return this.role.equals(role);
+    }
+}

--- a/src/main/java/com/forfour/global/auth/guards/Authorizable.java
+++ b/src/main/java/com/forfour/global/auth/guards/Authorizable.java
@@ -1,0 +1,9 @@
+package com.forfour.global.auth.guards;
+
+import com.forfour.domain.member.entity.Role;
+
+public interface Authorizable {
+
+    boolean isAuthorized(Role role);
+
+}

--- a/src/main/java/com/forfour/global/auth/guards/Guard.java
+++ b/src/main/java/com/forfour/global/auth/guards/Guard.java
@@ -1,0 +1,13 @@
+package com.forfour.global.auth.guards;
+
+
+import com.forfour.domain.member.entity.Role;
+
+public abstract class Guard {
+    public final Role role;
+
+    protected Guard(Role role) {
+        this.role = role;
+    }
+
+}

--- a/src/main/java/com/forfour/global/auth/guards/MemberGuard.java
+++ b/src/main/java/com/forfour/global/auth/guards/MemberGuard.java
@@ -1,0 +1,18 @@
+package com.forfour.global.auth.guards;
+
+import com.forfour.domain.member.entity.Role;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberGuard extends Guard implements Authorizable {
+
+    public MemberGuard() {
+        super(Role.MEMBER);
+    }
+
+    @Override
+    public boolean isAuthorized(Role role) {
+        return this.role.equals(role);
+    }
+
+}

--- a/src/main/java/com/forfour/global/config/AllowedOriginsConfig.java
+++ b/src/main/java/com/forfour/global/config/AllowedOriginsConfig.java
@@ -1,0 +1,15 @@
+package com.forfour.global.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AllowedOriginsConfig {
+
+    public String[] getAllowedOrigins(){
+        return new String[]{
+            "localhost:3000",
+            "localhost:5173"
+        };
+    }
+
+}

--- a/src/main/java/com/forfour/global/config/WebConfig.java
+++ b/src/main/java/com/forfour/global/config/WebConfig.java
@@ -1,0 +1,30 @@
+package com.forfour.global.config;
+
+
+import com.forfour.global.auth.AuthConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AllowedOriginsConfig originConfig;
+
+    /*
+     * TODO
+     * allowedOrigins "*" 대신 직접 명시하고 Credentials true로 변경
+     * */
+
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(originConfig.getAllowedOrigins())
+                .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS", "HEAD")
+                .allowedHeaders("*")
+                .exposedHeaders(AuthConstant.AUTH_HEADER, "Cache-Control", "Content-Type")
+                .allowCredentials(true);
+    }
+
+}

--- a/src/main/java/com/forfour/global/jwt/dto/JwtTokenClaimsDto.java
+++ b/src/main/java/com/forfour/global/jwt/dto/JwtTokenClaimsDto.java
@@ -1,0 +1,17 @@
+package com.forfour.global.jwt.dto;
+
+import com.forfour.domain.member.entity.Role;
+import lombok.Builder;
+
+@Builder
+public record JwtTokenClaimsDto(
+        Long memberId,
+        Role role
+){
+    public static JwtTokenClaimsDto of(final Long memberId, final String role) {
+        return JwtTokenClaimsDto.builder()
+                .memberId(memberId)
+                .role(Role.valueOf(role))
+                .build();
+    }
+}

--- a/src/main/java/com/forfour/global/jwt/dto/JwtTokenResponseDto.java
+++ b/src/main/java/com/forfour/global/jwt/dto/JwtTokenResponseDto.java
@@ -1,0 +1,14 @@
+package com.forfour.global.jwt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokenResponseDto(
+        String accessToken
+) {
+    public static JwtTokenResponseDto of(final String accessToken) {
+        return JwtTokenResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/forfour/global/jwt/service/JwtService.java
+++ b/src/main/java/com/forfour/global/jwt/service/JwtService.java
@@ -1,0 +1,45 @@
+package com.forfour.global.jwt.service;
+
+import com.forfour.domain.member.entity.Role;
+import com.forfour.global.jwt.JwtTokenType;
+import com.forfour.global.jwt.dto.JwtTokenClaimsDto;
+import com.forfour.global.jwt.dto.JwtTokenResponseDto;
+import com.forfour.global.jwt.exception.NotFoundJwtTokenException;
+import com.forfour.global.jwt.utils.JwtExtractor;
+import com.forfour.global.jwt.utils.JwtProvider;
+import com.forfour.global.jwt.utils.JwtValidator;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtProvider jwtProvider;
+    private final JwtValidator jwtValidator;
+    private final JwtExtractor jwtExtractor;
+
+    public JwtTokenResponseDto generateJwtToken(Long memberId, Role role) {
+        String accessToken = jwtProvider.generateToken(JwtTokenType.ACCESS_TOKEN, memberId, role.name());
+
+        return JwtTokenResponseDto.of(accessToken);
+    }
+
+    public String extractJwtToken(HttpServletRequest request) {
+        return jwtExtractor.extractJwtToken(request)
+                .orElseThrow(NotFoundJwtTokenException::new);
+    }
+
+    // 유효하지 않은 경우 예외 처리 -> void 반환.
+    public void isValidToken(String token) {
+        jwtValidator.verifyAccessToken(token);
+    }
+
+    public JwtTokenClaimsDto extractJwtToken(String token) {
+        Long id = jwtExtractor.getId(token);
+        String role = jwtExtractor.getRole(token);
+        return JwtTokenClaimsDto.of(id, role);
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

Spring AOP 인가 로직 구현

## Spring AOP

인가 작업은 주 비지니스 로직이 아니기 때문에 관심사를 분리하기 위해 AOP 사용.

## Spring Security

Spring Security는 Filter를 통해 강력한 인증 인가 로직 솔루션을 제공해줍니다.
그러나 인증, 요청에 대한 권한 검사(인가), 토큰 ID 만 필요한 간단한 어플리케이션에서 Security의 복잡성까지 도입할 필요성까지는 느끼지 못했습니다.

또한 Filter단에서 일어난 예외는 Handler를 통해 Spring Context와 별개로, 처리해야합니다. (불편함)

이러한 이유로 Spring Security보다는 
Spring AOP와 인가 작업을 추상화하여, 이번 프로젝트에서 필요한 인증, 인가, ThreadLocal을 직접 구현합니다.


## 📎 Issue #번호
<!-- closed #번호 -->