### PR TITLE
[Feat] 산책방 참여 API 구현

### DIFF
--- a/src/main/java/com/forfour/domain/member/facade/MemberFacade.java
+++ b/src/main/java/com/forfour/domain/member/facade/MemberFacade.java
@@ -4,7 +4,7 @@ import com.forfour.domain.member.dto.response.MemberEnterDto;
 import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.member.service.MemberGetService;
 import com.forfour.domain.member.service.MemberSaveService;
-import com.forfour.global.auth.facade.KakaoService;
+import com.forfour.global.auth.service.KakaoService;
 import com.forfour.global.jwt.dto.JwtTokenResponseDto;
 import com.forfour.global.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/forfour/domain/participant/entity/Participant.java
+++ b/src/main/java/com/forfour/domain/participant/entity/Participant.java
@@ -1,7 +1,5 @@
 package com.forfour.domain.participant.entity;
 
-import com.forfour.domain.member.entity.Member;
-import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -13,6 +11,12 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Getter
 @SuperBuilder
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "UK_participant_room_member",
+                columnNames = {"room_id", "memberId"}
+        )
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant extends BaseEntity {
 

--- a/src/main/java/com/forfour/domain/participant/service/ParticipantSaveService.java
+++ b/src/main/java/com/forfour/domain/participant/service/ParticipantSaveService.java
@@ -11,8 +11,8 @@ public class ParticipantSaveService {
 
     private final ParticipantRepository participantRepository;
 
-    public Participant save(Long roomId, Long leaderId) {
-        return participantRepository.save(Participant.of(roomId, leaderId));
+    public Participant save(Long roomId, Long memberId) {
+        return participantRepository.save(Participant.of(roomId, memberId));
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
+++ b/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ResponseMessage {
 
     ROOM_CREATED("[산책 방]을 생성했습니다."),
+    ROOM_PARTICIPANT("[산책 방]에 참여했습니다."),
     ;
 
     private final String meesage;

--- a/src/main/java/com/forfour/domain/room/controller/RoomController.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomController.java
@@ -9,6 +9,7 @@ import com.forfour.global.auth.guards.MemberGuard;
 import com.forfour.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +29,15 @@ public class RoomController implements RoomSwagger{
     ) {
         RoomDetailDto response = facade.createRoom(dto);
         return ApiResponse.response(HttpStatus.OK, ROOM_CREATED.getMeesage(), response);
+    }
+
+    @AuthGuard({MemberGuard.class, AdminGuard.class})
+    @PostMapping("/v1/room/{roomId}/participant")
+    public ApiResponse<Void> participateRoom(
+            @PathVariable Long roomId
+    ) {
+        facade.participateRoom(roomId);
+        return ApiResponse.response(HttpStatus.OK, ROOM_CREATED.getMeesage());
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
@@ -5,6 +5,7 @@ import com.forfour.domain.room.dto.response.RoomDetailDto;
 import com.forfour.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "산책 방")
@@ -12,5 +13,8 @@ public interface RoomSwagger {
 
     @Operation(description = "산책 방 생성 API", summary = "산책 방 생성 API")
     ApiResponse<RoomDetailDto> createRoom(@RequestBody RoomSaveDto dto);
+
+    @Operation(description = "산책 방 참여 API", summary = "산책 방 참여 API")
+    ApiResponse<Void> participateRoom(@PathVariable Long roomId);
 
 }

--- a/src/main/java/com/forfour/domain/room/dto/request/RoomSaveDto.java
+++ b/src/main/java/com/forfour/domain/room/dto/request/RoomSaveDto.java
@@ -19,6 +19,10 @@ public record RoomSaveDto(
         String missionName,
 
         @NotNull
+        @Schema(description = "최대 멤버 수", example = "10")
+        Integer maxMemberCount,
+
+        @NotNull
         @Schema(description = "산책 시간")
         LocalDateTime startAt
 ) {

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -1,6 +1,8 @@
 package com.forfour.domain.room.entity;
 
 import com.forfour.domain.room.dto.request.RoomSaveDto;
+import com.forfour.domain.room.exception.RoomIsFullException;
+import com.forfour.domain.room.exception.RoomIsNotRecruitingException;
 import com.forfour.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -28,6 +30,10 @@ public class Room extends BaseEntity {
 
     private Mission mission; // THINK 그냥 missionName 때려박아도 상관없지않을까?
 
+    private int maxMemberCount;
+
+    private int memberCount;
+
     @Enumerated(EnumType.STRING)
     private RoomStatus status;
 
@@ -43,9 +49,25 @@ public class Room extends BaseEntity {
                 .leaderId(leaderId)
                 .pathId(dto.pathId())
                 .mission(Mission.value(dto.missionName()))
+                .maxMemberCount(dto.maxMemberCount())
+                .memberCount(1)
                 .status(RoomStatus.RECRUITING)
                 .startAt(dto.startAt())
                 .build();
+    }
+
+    public void checkParticipate() {
+        if (status != RoomStatus.RECRUITING) {
+            throw new RoomIsNotRecruitingException();
+        }
+
+        if (this.memberCount == this.maxMemberCount) {
+            throw new RoomIsFullException();
+        }
+    }
+
+    public void increaseMemberCount() {
+        this.memberCount++;
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/exception/ErrorMessage.java
+++ b/src/main/java/com/forfour/domain/room/exception/ErrorMessage.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "[산책 방]을 찾을 수 없습니다."),
+    ROOM_IS_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "[산책 방]이 현재 모집 중이 아닙니다."),
+    ROOM_IS_FULL(HttpStatus.BAD_REQUEST, "[산책 방]의 회원수가 초과됐습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/forfour/domain/room/exception/ErrorMessage.java
+++ b/src/main/java/com/forfour/domain/room/exception/ErrorMessage.java
@@ -1,0 +1,17 @@
+package com.forfour.domain.room.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "[산책 방]을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/forfour/domain/room/exception/RoomIsFullException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RoomIsFullException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_IS_FULL;
+
+public class RoomIsFullException extends BaseException {
+    public RoomIsFullException() {
+        super(ROOM_IS_FULL.getStatus(), ROOM_IS_FULL.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/exception/RoomIsNotRecruitingException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RoomIsNotRecruitingException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_IS_NOT_RECRUITING;
+
+public class RoomIsNotRecruitingException extends BaseException {
+    public RoomIsNotRecruitingException() {
+        super(ROOM_IS_NOT_RECRUITING.getStatus(), ROOM_IS_NOT_RECRUITING.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/exception/RoomNotFoundException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RoomNotFoundException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_NOT_FOUND;
+
+public class RoomNotFoundException extends BaseException {
+    public RoomNotFoundException() {
+        super(ROOM_NOT_FOUND.getStatus(), ROOM_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
+++ b/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
@@ -7,16 +7,19 @@ import com.forfour.domain.path.service.PathGetService;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.dto.response.RoomDetailDto;
 import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.service.RoomGetService;
 import com.forfour.domain.room.service.RoomSaveService;
 import com.forfour.global.auth.context.MemberContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class RoomFacade {
 
     private final RoomSaveService roomSaveService;
+    private final RoomGetService roomGetService;
     private final ParticipantSaveService participantSaveService;
     private final PathGetService pathGetService;
     private final MemberGetService memberGetService;
@@ -29,6 +32,17 @@ public class RoomFacade {
         saveLeader(savedRoom.getId(), leader.getId());
 
         return RoomDetailDto.from(savedRoom, leader);
+    }
+
+    @Transactional
+    public void participateRoom(Long roomId) {
+        Long participantId = MemberContext.getMemberId();
+
+        Room room = roomGetService.getRoomUsingLock(roomId);
+        room.checkParticipate();
+
+        participantSaveService.save(roomId, participantId);
+        room.increaseMemberCount();
     }
 
     private void saveLeader(Long roomId, Long leaderId) {

--- a/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
+++ b/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
@@ -29,7 +29,7 @@ public class RoomFacade {
 
         Member leader = memberGetService.getMember(MemberContext.getMemberId());
         Room savedRoom = roomSaveService.save(dto, leader.getId());
-        saveLeader(savedRoom.getId(), leader.getId());
+        enterRoom(savedRoom.getId(), leader.getId());
 
         return RoomDetailDto.from(savedRoom, leader);
     }
@@ -39,11 +39,12 @@ public class RoomFacade {
         Room room = roomGetService.getRoomUsingLock(roomId);
         room.checkParticipate();
 
-        participantSaveService.save(roomId, MemberContext.getMemberId());
+        Long participantId = MemberContext.getMemberId();
+        enterRoom(room.getId(), participantId);
         room.increaseMemberCount();
     }
 
-    private void saveLeader(Long roomId, Long leaderId) {
+    private void enterRoom(Long roomId, Long leaderId) {
         participantSaveService.save(roomId, leaderId);
     }
 

--- a/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
+++ b/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
@@ -36,12 +36,10 @@ public class RoomFacade {
 
     @Transactional
     public void participateRoom(Long roomId) {
-        Long participantId = MemberContext.getMemberId();
-
         Room room = roomGetService.getRoomUsingLock(roomId);
         room.checkParticipate();
 
-        participantSaveService.save(roomId, participantId);
+        participantSaveService.save(roomId, MemberContext.getMemberId());
         room.increaseMemberCount();
     }
 

--- a/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
@@ -1,9 +1,20 @@
 package com.forfour.domain.room.repository;
 
 import com.forfour.domain.room.entity.Room;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Room r WHERE r.id = :id")
+    Optional<Room> findByIdWithPessimisticLock(@Param("id") Long id);
+
 }

--- a/src/main/java/com/forfour/domain/room/service/RoomGetService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomGetService.java
@@ -1,0 +1,20 @@
+package com.forfour.domain.room.service;
+
+import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.exception.RoomNotFoundException;
+import com.forfour.domain.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomGetService {
+
+    private final RoomRepository roomRepository;
+
+    public Room getRoom(Long roomId) {
+        return roomRepository.findById(roomId)
+                .orElseThrow(RoomNotFoundException::new);
+    }
+
+}

--- a/src/main/java/com/forfour/domain/room/service/RoomGetService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomGetService.java
@@ -17,4 +17,9 @@ public class RoomGetService {
                 .orElseThrow(RoomNotFoundException::new);
     }
 
+    public Room getRoomUsingLock(Long roomId) {
+        return roomRepository.findByIdWithPessimisticLock(roomId)
+                .orElseThrow(RoomNotFoundException::new);
+    }
+
 }

--- a/src/main/java/com/forfour/global/auth/service/KakaoService.java
+++ b/src/main/java/com/forfour/global/auth/service/KakaoService.java
@@ -1,6 +1,5 @@
-package com.forfour.global.auth.facade;
+package com.forfour.global.auth.service;
 
-import com.forfour.domain.member.service.MemberGetService;
 import com.forfour.global.auth.kakao.dto.KaKaoDTO;
 import com.forfour.global.auth.kakao.utils.KakaoUtil;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 📄 작업 내용 요약
산책방 참여 API 구현

## 산책 방 참여 API 구현

Room은 memberCount를 두고,
Participant를 생성할 때 마다 memberCount가 증가합니다.


## Room 참여 조건
1. Room의 상태가 `모집 중`이어야한다.
2. 정원이 초과되면 안된다.


## 비관적 락 사용
동시성 제어를 위해 비관적 락을 사용
비관적 락을 사용한 가장 큰 이유는 `구현 난이도`입니다.

초기 어플리케이션 상 동시성 충돌이 발생할 가능성은 낮아 낙관적 락을 사용하는 것이 효과적입니다.
그러나, 주어진 개발 기간이 2주 밖에 되지 않으므로, 비교적 재시도 로직에 신경쓰지 않아도 되는 비관적 락을 사용했습니다.

## 📎 Issue #20 
<!-- closed #20 -->