### PR TITLE
[Feat] 산책 방 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
+++ b/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
@@ -9,6 +9,7 @@ public enum ResponseMessage {
 
     ROOM_CREATED("[산책 방]을 생성했습니다."),
     ROOM_PARTICIPANT("[산책 방]에 참여했습니다."),
+    ROOM_SCROLL_LIST_READ("[산책 방]에 목록을 조회합니다."),
     ;
 
     private final String meesage;

--- a/src/main/java/com/forfour/domain/room/controller/RoomController.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomController.java
@@ -2,19 +2,23 @@ package com.forfour.domain.room.controller;
 
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.dto.response.RoomDetailDto;
+import com.forfour.domain.room.dto.response.SliceRoomDto;
+import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.domain.room.facade.RoomFacade;
 import com.forfour.global.auth.annotations.AuthGuard;
 import com.forfour.global.auth.guards.AdminGuard;
 import com.forfour.global.auth.guards.MemberGuard;
 import com.forfour.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import static com.forfour.domain.room.controller.ResponseMessage.ROOM_CREATED;
+import static com.forfour.domain.room.controller.ResponseMessage.ROOM_SCROLL_LIST_READ;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +29,7 @@ public class RoomController implements RoomSwagger{
     @AuthGuard({MemberGuard.class, AdminGuard.class})
     @PostMapping("/v1/room")
     public ApiResponse<RoomDetailDto> createRoom(
-            @RequestBody RoomSaveDto dto
+            @RequestBody @Validated RoomSaveDto dto
     ) {
         RoomDetailDto response = facade.createRoom(dto);
         return ApiResponse.response(HttpStatus.OK, ROOM_CREATED.getMeesage(), response);
@@ -38,6 +42,18 @@ public class RoomController implements RoomSwagger{
     ) {
         facade.participateRoom(roomId);
         return ApiResponse.response(HttpStatus.OK, ROOM_CREATED.getMeesage());
+    }
+
+    @AuthGuard({MemberGuard.class, AdminGuard.class})
+    @GetMapping("/v1/room-list")
+    public ApiResponse<SliceRoomDto> scrollRoom(
+            @RequestParam int pageSize,
+            @RequestParam int pageNum,
+            @Schema(implementation = RoomStatus.class)
+            @RequestParam @Nullable String roomStatus
+    ) {
+        SliceRoomDto response = facade.readRoomScrollList(pageSize, pageNum, roomStatus);
+        return ApiResponse.response(HttpStatus.OK, ROOM_SCROLL_LIST_READ.getMeesage(), response);
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
@@ -2,11 +2,17 @@ package com.forfour.domain.room.controller;
 
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.dto.response.RoomDetailDto;
+import com.forfour.domain.room.dto.response.SliceRoomDto;
+import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "산책 방")
 public interface RoomSwagger {
@@ -16,5 +22,14 @@ public interface RoomSwagger {
 
     @Operation(description = "산책 방 참여 API", summary = "산책 방 참여 API")
     ApiResponse<Void> participateRoom(@PathVariable Long roomId);
+
+    @Operation(description = "산책 방 목록 조회 API", summary = "산책 방 목록 조회 API")
+    ApiResponse<SliceRoomDto> scrollRoom(
+            @RequestParam int pageSize,
+            @RequestParam int pageNum,
+
+            @Schema(implementation = RoomStatus.class)
+            @RequestParam @Nullable String roomStatus
+    );
 
 }

--- a/src/main/java/com/forfour/domain/room/dto/response/RoomDetailDto.java
+++ b/src/main/java/com/forfour/domain/room/dto/response/RoomDetailDto.java
@@ -18,12 +18,25 @@ public record RoomDetailDto(
         RoomStatus status,
         LocalDateTime startAt
 ) {
-    public static RoomDetailDto from(Room room, Member leader) {
+    public static RoomDetailDto of(Room room, Member leader) {
         return RoomDetailDto.builder()
                 .roomId(room.getId())
                 .title(room.getTitle())
-                .leaderId(room.getLeaderId())
+                .leaderId(leader.getId())
                 .leaderName(leader.getNickname())
+                .pathId(room.getPathId())
+                .missionName(room.getMission().name())
+                .status(room.getStatus())
+                .startAt(room.getStartAt())
+                .build();
+    }
+
+    public static RoomDetailDto from(Room room) {
+        return RoomDetailDto.builder()
+                .roomId(room.getId())
+                .title(room.getTitle())
+                .leaderId(room.getLeader().getId())
+                .leaderName(room.getLeader().getNickname())
                 .pathId(room.getPathId())
                 .missionName(room.getMission().name())
                 .status(room.getStatus())

--- a/src/main/java/com/forfour/domain/room/dto/response/SliceRoomDto.java
+++ b/src/main/java/com/forfour/domain/room/dto/response/SliceRoomDto.java
@@ -1,0 +1,24 @@
+package com.forfour.domain.room.dto.response;
+
+import com.forfour.domain.room.entity.Room;
+import com.forfour.global.common.dto.PageableDto;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record SliceRoomDto(
+        List<RoomDetailDto> dataList,
+        PageableDto pageable
+) {
+    public static SliceRoomDto from(Slice<Room> slice) {
+        List<RoomDetailDto> dataList = slice.map(RoomDetailDto::from)
+                .toList();
+
+        return SliceRoomDto.builder()
+                .dataList(dataList)
+                .pageable(PageableDto.from(slice))
+                .build();
+    }
+}

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.room.entity;
 
+import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.exception.RoomIsFullException;
 import com.forfour.domain.room.exception.RoomIsNotRecruitingException;
@@ -24,7 +25,9 @@ public class Room extends BaseEntity {
 
     private String title;
 
-    private Long leaderId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leaderId", referencedColumnName = "id")
+    private Member leader;
 
     private Long pathId;
 
@@ -33,6 +36,8 @@ public class Room extends BaseEntity {
     private int maxMemberCount;
 
     private int memberCount;
+
+    private boolean isActive;
 
     @Enumerated(EnumType.STRING)
     private RoomStatus status;
@@ -43,16 +48,17 @@ public class Room extends BaseEntity {
 
     private LocalDateTime stopwatchEndAt;
 
-    public static Room of(RoomSaveDto dto, Long leaderId) {
+    public static Room of(RoomSaveDto dto, Member leader) {
         return Room.builder()
                 .title(dto.title())
-                .leaderId(leaderId)
+                .leader(leader)
                 .pathId(dto.pathId())
                 .mission(Mission.value(dto.missionName()))
                 .maxMemberCount(dto.maxMemberCount())
                 .memberCount(1)
                 .status(RoomStatus.RECRUITING)
                 .startAt(dto.startAt())
+                .isActive(true)
                 .build();
     }
 

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -76,4 +76,8 @@ public class Room extends BaseEntity {
         this.memberCount++;
     }
 
+    public void closed() {
+        this.isActive = false;
+    }
+
 }

--- a/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
+++ b/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
@@ -6,11 +6,17 @@ import com.forfour.domain.participant.service.ParticipantSaveService;
 import com.forfour.domain.path.service.PathGetService;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.dto.response.RoomDetailDto;
+import com.forfour.domain.room.dto.response.SliceRoomDto;
 import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.domain.room.service.RoomGetService;
 import com.forfour.domain.room.service.RoomSaveService;
 import com.forfour.global.auth.context.MemberContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,10 +34,10 @@ public class RoomFacade {
         pathGetService.validatePath(dto.pathId());
 
         Member leader = memberGetService.getMember(MemberContext.getMemberId());
-        Room savedRoom = roomSaveService.save(dto, leader.getId());
+        Room savedRoom = roomSaveService.save(dto, leader);
         enterRoom(savedRoom.getId(), leader.getId());
 
-        return RoomDetailDto.from(savedRoom, leader);
+        return RoomDetailDto.of(savedRoom, leader);
     }
 
     @Transactional
@@ -42,6 +48,18 @@ public class RoomFacade {
         Long participantId = MemberContext.getMemberId();
         enterRoom(room.getId(), participantId);
         room.increaseMemberCount();
+    }
+
+    public SliceRoomDto readRoomScrollList(int pageSize, int pageNum, String roomStatus) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createdAt").descending());
+
+        if (roomStatus == null || roomStatus.isBlank()) {
+            Slice<Room> slice = roomGetService.getActiveRooms(pageable);
+            return SliceRoomDto.from(slice);
+        }
+
+        Slice<Room> slice = roomGetService.getActiveRoomsWithStatus(RoomStatus.valueOf(roomStatus), pageable);
+        return SliceRoomDto.from(slice);
     }
 
     private void enterRoom(Long roomId, Long leaderId) {

--- a/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
@@ -1,7 +1,10 @@
 package com.forfour.domain.room.repository;
 
 import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.entity.RoomStatus;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -16,5 +19,20 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM Room r WHERE r.id = :id")
     Optional<Room> findByIdWithPessimisticLock(@Param("id") Long id);
+
+    @Query("SELECT r FROM Room r LEFT JOIN FETCH r.leader " +
+            "WHERE r.isActive = true " +
+            "AND r.status = :status")
+    Slice<Room> findActiveRoomsWithStatus(
+            @Param("status") RoomStatus roomStatus,
+            Pageable pageable
+    );
+
+    @Query("SELECT r FROM Room r LEFT JOIN FETCH r.leader " +
+            "WHERE r.isActive = true ")
+    Slice<Room> findActiveRooms(
+            Pageable pageable
+    );
+
 
 }

--- a/src/main/java/com/forfour/domain/room/service/RoomGetService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomGetService.java
@@ -1,9 +1,12 @@
 package com.forfour.domain.room.service;
 
 import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.domain.room.exception.RoomNotFoundException;
 import com.forfour.domain.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,6 +23,14 @@ public class RoomGetService {
     public Room getRoomUsingLock(Long roomId) {
         return roomRepository.findByIdWithPessimisticLock(roomId)
                 .orElseThrow(RoomNotFoundException::new);
+    }
+
+    public Slice<Room> getActiveRooms(Pageable pageable) {
+        return roomRepository.findActiveRooms(pageable);
+    }
+
+    public Slice<Room> getActiveRoomsWithStatus(RoomStatus status, Pageable pageable) {
+        return roomRepository.findActiveRoomsWithStatus(status, pageable);
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/service/RoomSaveService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomSaveService.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.room.service;
 
+import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.repository.RoomRepository;
@@ -12,8 +13,8 @@ public class RoomSaveService {
 
     private final RoomRepository roomRepository;
 
-    public Room save(RoomSaveDto dto, Long leaderId) {
-        return roomRepository.save(Room.of(dto, leaderId));
+    public Room save(RoomSaveDto dto, Member leader) {
+        return roomRepository.save(Room.of(dto, leader));
     }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
산책 방 목록 조회 API 구현

## 조회 기준

roomStatus (방 상태)에 대해서 필터링을 받습니다.
만약 roomStatus가 없을 경우, 생성된 방을 기준으로 조회합니다.
단, 산책이 이미 종료되거나 취소된 방은 조회되지 않습니다.

## @OneToOne 으로 변경
원래는 Room 엔티티의 필드에 Long leaderId를 사용했으나,

Leader의 Nickname이 모든 화면에서 필요합니다.
이는 Room과 Leader의 Nickname의 생명주기가 같다고 판단하여, Fetch Join을 사용하기 위해 OneToOne으로 연관관계를 걸어두었습니다.

Room필드에 String leaderNickname을 추가하고 Nickname이 수정될 경우,
한번에 수정할까 (Member와 Room의 nickname 정보) 고민했습니다.
그러나 추가 요구사항이 생길 경우 연관관계를 통해 Member의 모든 정보에 접근할 수 있는 게 좋다고 생각했습니다.

## 📎 Issue #22 
<!-- closed #22 -->