### PR TITLE
[Feat] 산책방 모집 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
+++ b/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
     ROOM_PARTICIPANT("[산책 방]에 참여했습니다."),
     ROOM_SCROLL_LIST_READ("[산책 방]에 목록을 조회합니다."),
     ROOM_READ("[산책 방 + 참여자 정보]를 조회합니다."),
+    ROOM_RECRUIT_STATUS_UPDATED("[산책방 모집 상태]를 변경합니다."),
     ;
 
     private final String meesage;

--- a/src/main/java/com/forfour/domain/room/controller/RoomController.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomController.java
@@ -57,11 +57,20 @@ public class RoomController implements RoomSwagger{
     public ApiResponse<SliceRoomDto> scrollRoom(
             @RequestParam int pageSize,
             @RequestParam int pageNum,
-            @Schema(implementation = RoomStatus.class)
             @RequestParam @Nullable String roomStatus
     ) {
         SliceRoomDto response = facade.readRoomScrollList(pageSize, pageNum, roomStatus);
         return ApiResponse.response(HttpStatus.OK, ROOM_SCROLL_LIST_READ.getMeesage(), response);
+    }
+
+    @AuthGuard({MemberGuard.class, AdminGuard.class})
+    @PatchMapping("/v1/room/{roomId}/recruit-status")
+    public ApiResponse<Void> updateRoomRecruitStatus(
+            @PathVariable Long roomId,
+            @RequestParam String roomStatus
+    ) {
+        facade.updateRecruitStatus(roomId, roomStatus);
+        return ApiResponse.response(HttpStatus.OK, ROOM_RECRUIT_STATUS_UPDATED.getMeesage());
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
@@ -5,12 +5,16 @@ import com.forfour.domain.room.dto.response.RoomDetailDto;
 import com.forfour.domain.room.dto.response.RoomWithParticipantsDto;
 import com.forfour.domain.room.dto.response.SliceRoomDto;
 import com.forfour.domain.room.entity.RoomStatus;
+import com.forfour.global.auth.annotations.AuthGuard;
+import com.forfour.global.auth.guards.AdminGuard;
+import com.forfour.global.auth.guards.MemberGuard;
 import com.forfour.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,9 +35,15 @@ public interface RoomSwagger {
     ApiResponse<SliceRoomDto> scrollRoom(
             @RequestParam int pageSize,
             @RequestParam int pageNum,
-
             @Schema(implementation = RoomStatus.class)
             @RequestParam @Nullable String roomStatus
+    );
+
+    @Operation(description = "산책 모집 상태 변경 API", summary = "산책 모집 상태 변경 API")
+    ApiResponse<Void> updateRoomRecruitStatus(
+            @PathVariable Long roomId,
+            @Schema(example = "RECRUITING, RECRUITMENT_ENDED")
+            @RequestParam String roomStatus
     );
 
 }

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -4,6 +4,7 @@ import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.exception.RoomIsFullException;
 import com.forfour.domain.room.exception.RoomIsNotRecruitingException;
+import com.forfour.domain.room.exception.RoomNotEnoughMinimumException;
 import com.forfour.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,6 +20,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Room extends BaseEntity {
 
+    private static final int MINIMUM_MEMBER_COUNT = 3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -31,7 +34,7 @@ public class Room extends BaseEntity {
 
     private Long pathId;
 
-    private Mission mission; // THINK 그냥 missionName 때려박아도 상관없지않을까?
+    private Mission mission;
 
     private int maxMemberCount;
 
@@ -78,6 +81,20 @@ public class Room extends BaseEntity {
 
     public void closed() {
         this.isActive = false;
+    }
+
+    public boolean checkStatus(RoomStatus status) {
+        return this.status == status;
+    }
+
+    public void updateStatus(RoomStatus status) {
+        this.status = status;
+    }
+
+    public void validateMinimumMember() {
+        if (this.memberCount < MINIMUM_MEMBER_COUNT) {
+            throw new RoomNotEnoughMinimumException();
+        }
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/entity/RoomStatus.java
+++ b/src/main/java/com/forfour/domain/room/entity/RoomStatus.java
@@ -1,11 +1,19 @@
 package com.forfour.domain.room.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum RoomStatus {
 
-    RECRUITING, // 모집 중
-    RECRUITMENT_ENDED, // 모집 종료
-    CANCELED, // 산책 취소
-    PROGRESS, // 산책 중
-    COMPLETED // 산책 완료
+    RECRUITING("모집 중"),
+    RECRUITMENT_ENDED("모집 종료"),
+    CANCELED("산책 취소"),
+    PROGRESS("산책 중"),
+    COMPLETED("산책 완료"),
+    ;
+
+    private final String message;
 
 }

--- a/src/main/java/com/forfour/domain/room/exception/ErrorMessage.java
+++ b/src/main/java/com/forfour/domain/room/exception/ErrorMessage.java
@@ -11,6 +11,11 @@ public enum ErrorMessage {
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "[산책 방]을 찾을 수 없습니다."),
     ROOM_IS_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "[산책 방]이 현재 모집 중이 아닙니다."),
     ROOM_IS_FULL(HttpStatus.BAD_REQUEST, "[산책 방]의 회원수가 초과됐습니다."),
+    ROOM_DO_NOT_UPDATE_STATUS(HttpStatus.BAD_REQUEST, "에는 산책방 상태를 변경할 수 없습니다."),
+    ROOM_NOT_ENOUGH_MINIMUM_MEMBER(HttpStatus.BAD_REQUEST, "[산책 방]의 최소 인원을 만족하지 못했습니다."),
+
+    ROOM_RECRUIT_STRATEGY_NOT_MATCH(HttpStatus.BAD_REQUEST, "[모집 중], 혹은 [모집 종료]으로만 변경 가능합니다."),
+    ROOM_LEADER_NOT_EQUAL(HttpStatus.BAD_REQUEST, "산책 방의 [방장]이 아닙니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/forfour/domain/room/exception/RecruitStrategyNotMatchException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RecruitStrategyNotMatchException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_RECRUIT_STRATEGY_NOT_MATCH;
+
+public class RecruitStrategyNotMatchException extends BaseException {
+    public RecruitStrategyNotMatchException() {
+        super(ROOM_RECRUIT_STRATEGY_NOT_MATCH.getStatus(), ROOM_RECRUIT_STRATEGY_NOT_MATCH.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/exception/RoomDoNotUpdateStatusException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RoomDoNotUpdateStatusException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_DO_NOT_UPDATE_STATUS;
+
+public class RoomDoNotUpdateStatusException extends BaseException {
+    public RoomDoNotUpdateStatusException(String status) {
+        super(ROOM_DO_NOT_UPDATE_STATUS.getStatus(), status + ROOM_DO_NOT_UPDATE_STATUS.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/exception/RoomLeaderNotEqualException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RoomLeaderNotEqualException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_LEADER_NOT_EQUAL;
+
+public class RoomLeaderNotEqualException extends BaseException {
+    public RoomLeaderNotEqualException() {
+        super(ROOM_LEADER_NOT_EQUAL.getStatus(), ROOM_LEADER_NOT_EQUAL.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/exception/RoomNotEnoughMinimumException.java
+++ b/src/main/java/com/forfour/domain/room/exception/RoomNotEnoughMinimumException.java
@@ -1,0 +1,11 @@
+package com.forfour.domain.room.exception;
+
+import com.forfour.global.common.exception.BaseException;
+
+import static com.forfour.domain.room.exception.ErrorMessage.ROOM_NOT_ENOUGH_MINIMUM_MEMBER;
+
+public class RoomNotEnoughMinimumException extends BaseException {
+    public RoomNotEnoughMinimumException() {
+        super(ROOM_NOT_ENOUGH_MINIMUM_MEMBER.getStatus(), ROOM_NOT_ENOUGH_MINIMUM_MEMBER.getMessage());
+    }
+}

--- a/src/main/java/com/forfour/domain/room/service/RoomGetService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomGetService.java
@@ -2,12 +2,15 @@ package com.forfour.domain.room.service;
 
 import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.entity.RoomStatus;
+import com.forfour.domain.room.exception.RoomLeaderNotEqualException;
 import com.forfour.domain.room.exception.RoomNotFoundException;
 import com.forfour.domain.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/forfour/domain/room/strategy/RecruitStatusStrategy.java
+++ b/src/main/java/com/forfour/domain/room/strategy/RecruitStatusStrategy.java
@@ -1,0 +1,12 @@
+package com.forfour.domain.room.strategy;
+
+import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.entity.RoomStatus;
+
+public interface RecruitStatusStrategy {
+
+    boolean support(RoomStatus roomStatus);
+
+    void apply(Room room);
+
+}

--- a/src/main/java/com/forfour/domain/room/strategy/RecruitingEndStrategy.java
+++ b/src/main/java/com/forfour/domain/room/strategy/RecruitingEndStrategy.java
@@ -1,0 +1,42 @@
+package com.forfour.domain.room.strategy;
+
+import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.entity.RoomStatus;
+import com.forfour.domain.room.exception.RoomDoNotUpdateStatusException;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+@Component
+public class RecruitingEndStrategy implements RecruitStatusStrategy {
+    @Override
+    public boolean support(RoomStatus roomStatus) {
+        return roomStatus.equals(RoomStatus.RECRUITMENT_ENDED);
+    }
+
+    @Override
+    public void apply(Room room) {
+        validateUpdateCondition(room);
+        updateRoomStatus(room);
+    }
+
+    private void validateUpdateCondition(Room room) {
+        RoomStatus roomStatus = filterRoomStrategy(room);
+        if (roomStatus != null) {
+            throw new RoomDoNotUpdateStatusException(roomStatus.getMessage());
+        }
+        room.validateMinimumMember();
+    }
+
+    private void updateRoomStatus(Room room) {
+        room.updateStatus(RoomStatus.RECRUITMENT_ENDED);
+    }
+
+    private RoomStatus filterRoomStrategy(Room room) {
+        return Stream.of(RoomStatus.CANCELED, RoomStatus.PROGRESS, RoomStatus.COMPLETED, RoomStatus.RECRUITMENT_ENDED)
+                .filter(room::checkStatus)
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/src/main/java/com/forfour/domain/room/strategy/RecruitingStrategy.java
+++ b/src/main/java/com/forfour/domain/room/strategy/RecruitingStrategy.java
@@ -1,0 +1,42 @@
+package com.forfour.domain.room.strategy;
+
+import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.entity.RoomStatus;
+import com.forfour.domain.room.exception.RoomDoNotUpdateStatusException;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+@Component
+public class RecruitingStrategy implements RecruitStatusStrategy {
+
+    @Override
+    public boolean support(RoomStatus roomStatus) {
+        return roomStatus.equals(RoomStatus.RECRUITING);
+    }
+
+    @Override
+    public void apply(Room room) {
+        validateUpdateCondition(room);
+        updateRoomStatus(room);
+    }
+
+    private void validateUpdateCondition(Room room) {
+        RoomStatus roomStatus = filterRoomStrategy(room);
+        if (roomStatus != null) {
+            throw new RoomDoNotUpdateStatusException(roomStatus.getMessage());
+        }
+    }
+
+    private RoomStatus filterRoomStrategy(Room room) {
+        return Stream.of(RoomStatus.RECRUITING, RoomStatus.CANCELED, RoomStatus.PROGRESS, RoomStatus.COMPLETED)
+                .filter(room::checkStatus)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void updateRoomStatus(Room room) {
+        room.updateStatus(RoomStatus.RECRUITING);
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
산책방 모집 상태 변경 API 구현

`모집 중` <-> `모집 종료`의 상태만 변경하는 API를 구현합니다.

## 📎 Issue #25 
<!-- closed #25 -->