### PR TITLE
[Feat] 산책 시작 API 구현

### DIFF
--- a/src/main/java/com/forfour/domain/participant/entity/Participant.java
+++ b/src/main/java/com/forfour/domain/participant/entity/Participant.java
@@ -42,4 +42,8 @@ public class Participant extends BaseEntity {
                 .build();
     }
 
+    public void updateStatus(RoomStatus roomStatus) {
+        this.roomStatus = roomStatus;
+    }
+
 }

--- a/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
+++ b/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
@@ -12,6 +12,7 @@ public enum ResponseMessage {
     ROOM_SCROLL_LIST_READ("[산책 방]에 목록을 조회합니다."),
     ROOM_READ("[산책 방 + 참여자 정보]를 조회합니다."),
     ROOM_RECRUIT_STATUS_UPDATED("[산책방 모집 상태]를 변경합니다."),
+    WALKING_START("[산책]을 시작합니다."),
     ;
 
     private final String meesage;

--- a/src/main/java/com/forfour/domain/room/controller/RoomController.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomController.java
@@ -73,4 +73,14 @@ public class RoomController implements RoomSwagger{
         return ApiResponse.response(HttpStatus.OK, ROOM_RECRUIT_STATUS_UPDATED.getMeesage());
     }
 
+    @AuthGuard({MemberGuard.class, AdminGuard.class})
+    @PatchMapping("/v1/room/{roomId}/market/{marketId}")
+    public ApiResponse<Void> startWalking(
+            @PathVariable Long roomId,
+            @PathVariable String marketId
+    ) {
+        facade.startWalking(roomId, marketId);
+        return ApiResponse.response(HttpStatus.OK, WALKING_START.getMeesage());
+    }
+
 }

--- a/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
@@ -46,4 +46,10 @@ public interface RoomSwagger {
             @RequestParam String roomStatus
     );
 
+    @Operation(description = "산책 시작 API", summary = "산책 시작 API")
+    ApiResponse<Void> startWalking(
+            @PathVariable Long roomId,
+            @PathVariable String marketId
+    );
+
 }

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -4,6 +4,7 @@ import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.exception.RoomIsFullException;
 import com.forfour.domain.room.exception.RoomIsNotRecruitingException;
+import com.forfour.domain.room.exception.RoomLeaderNotEqualException;
 import com.forfour.domain.room.exception.RoomNotEnoughMinimumException;
 import com.forfour.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -81,6 +82,12 @@ public class Room extends BaseEntity {
 
     public void closed() {
         this.isActive = false;
+    }
+
+    public void validateRoomLeader(Long memberId) {
+        if(this.leader.getId() != memberId) {
+            throw new RoomLeaderNotEqualException();
+        }
     }
 
     public boolean checkStatus(RoomStatus status) {

--- a/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
+++ b/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
@@ -90,6 +90,7 @@ public class RoomFacade {
         statusStrategy.apply(room);
     }
 
+    // TODO Spring Event 관심사 분리
     @Transactional
     public void startWalking(Long roomId, String marketId) {
         Room room = roomGetService.getRoomUsingLock(roomId);

--- a/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
+++ b/src/main/java/com/forfour/domain/room/facade/RoomFacade.java
@@ -84,7 +84,7 @@ public class RoomFacade {
     @Transactional
     public void updateRecruitStatus(Long roomId, String roomStatus) {
         Room room = roomGetService.getRoomUsingLock(roomId);
-        validateRoomLeader(room, MemberContext.getMemberId());
+        room.validateRoomLeader(MemberContext.getMemberId());
 
         RecruitStatusStrategy statusStrategy = findRecruitStrategy(RoomStatus.valueOf(roomStatus));
         statusStrategy.apply(room);
@@ -115,12 +115,6 @@ public class RoomFacade {
 
     private void enterRoom(Long roomId, Member member) {
         participantSaveService.save(roomId, member);
-    }
-
-    private void validateRoomLeader(Room room, Long memberId) {
-        if(!Objects.equals(room.getLeader().getId(), memberId)) {
-            throw new RoomLeaderNotEqualException();
-        }
     }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
산책 시작 API 구현

## 개선 점
참가자(Participant)의 상태 역시 수정하는 로직을 RoomFacade로부터 분리.
-> Event로 관심사 분리하면 좋을 듯 합니다.

## 📎 Issue #번호
<!-- closed #번호 -->