### PR TITLE
[Feat] 참가자 상태 변경 로직은 Event 를 통해 관심사 분리

### DIFF
--- a/src/main/java/com/forfour/domain/participant/facade/ParticipantFacade.java
+++ b/src/main/java/com/forfour/domain/participant/facade/ParticipantFacade.java
@@ -1,0 +1,27 @@
+package com.forfour.domain.participant.facade;
+
+import com.forfour.domain.participant.service.ParticipantGetService;
+import com.forfour.domain.room.entity.RoomStatus;
+import com.forfour.domain.room.event.RoomStartEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantFacade {
+
+    private final ParticipantGetService participantGetService;
+
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void updateWalkingStatus(RoomStartEvent event) {
+        Long roomId = event.roomId();
+        RoomStatus status = event.status();
+        participantGetService.getParticipants(roomId)
+                .forEach(p -> p.updateStatus(status));
+    }
+
+}

--- a/src/main/java/com/forfour/domain/room/event/RoomStartEvent.java
+++ b/src/main/java/com/forfour/domain/room/event/RoomStartEvent.java
@@ -1,0 +1,17 @@
+package com.forfour.domain.room.event;
+
+import com.forfour.domain.room.entity.RoomStatus;
+import lombok.Builder;
+
+@Builder
+public record RoomStartEvent(
+        Long roomId,
+        RoomStatus status
+) {
+    public static RoomStartEvent of(final Long roomId, final RoomStatus status) {
+        return RoomStartEvent.builder()
+                .roomId(roomId)
+                .status(status)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

참가자 상태 변경 로직은 Event 를 통해 관심사를 분리합니다.

빠른 응답을 위해 @Async를 사용할 수 있으나, 별도의 트랜잭션으로 수행될 경우, 롤백처리에 어려움이 있다는 점에서 사용하지 않았습니다.

결론적으로 Event를 사용하여 Participant와 Room의 상태 변경 관심사를 분리했습니다.

## 📎 Issue #34 
<!-- closed #34 -->