### PR TITLE
[Feat] 내가 참여한 산책방 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/forfour/domain/market/service/MarketGetService.java
+++ b/src/main/java/com/forfour/domain/market/service/MarketGetService.java
@@ -16,6 +16,11 @@ public class MarketGetService {
 
     private final MarketRepository marketRepository;
 
+    public Market getMarketById(String uuid) {
+        return marketRepository.findById(UUID.fromString(uuid))
+                .orElseThrow(() -> new MarketException(MarketExceptionInformation.MARKET_NOT_FOUND));
+    }
+
     public void validateMarket(String marketId) {
         if (!marketRepository.existsById(UUID.fromString(marketId))) {
             throw new MarketException(MarketExceptionInformation.MARKET_NOT_FOUND);

--- a/src/main/java/com/forfour/domain/member/facade/MemberFacade.java
+++ b/src/main/java/com/forfour/domain/member/facade/MemberFacade.java
@@ -7,6 +7,8 @@ import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.member.service.MemberGetService;
 import com.forfour.domain.member.service.MemberSaveService;
 import com.forfour.domain.participant.service.ParticipantGetService;
+import com.forfour.domain.room.entity.Room;
+import com.forfour.domain.room.service.RoomGetService;
 import com.forfour.global.auth.context.MemberContext;
 import com.forfour.global.auth.service.KakaoService;
 import com.forfour.global.jwt.dto.JwtTokenResponseDto;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -25,6 +28,7 @@ public class MemberFacade {
     private final JwtService jwtService;
     private final MemberGetService memberGetService;
     private final MemberSaveService memberSaveService;
+    private final RoomGetService roomGetService;
     private final ParticipantGetService participantGetService;
 
     public MemberEnterDto kakaoLogin(String authCode) {
@@ -47,7 +51,14 @@ public class MemberFacade {
     @Transactional
     public MemberDetailDto updateNickname(NickNameUpdateDto dto) {
         Member member = memberGetService.getMember(MemberContext.getMemberId());
-        member.updateNickname(dto.nickname());
+        String newName = dto.nickname();
+        member.updateNickname(newName);
+
+        List<Room> rooms = roomGetService.findByLeaderAndStatusNot(member);
+        for (Room room : rooms) {
+            room.updateLeaderName(newName);
+        }
+
         return MemberDetailDto.from(member);
     }
 

--- a/src/main/java/com/forfour/domain/participant/dto/response/MyParticipationDto.java
+++ b/src/main/java/com/forfour/domain/participant/dto/response/MyParticipationDto.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.participant.dto.response;
 
+import com.forfour.domain.room.entity.Room;
 import lombok.Builder;
 
 @Builder
@@ -7,10 +8,10 @@ public record MyParticipationDto(
         boolean hasActiveRoom,
         Long roomId
 ) {
-    public static MyParticipationDto from(boolean hasActiveRoom, Long roomId) {
+    public static MyParticipationDto from(boolean hasActiveRoom, Room room) {
         return MyParticipationDto.builder()
                 .hasActiveRoom(hasActiveRoom)
-                .roomId(roomId)
+                .roomId(room.getId())
                 .build();
     }
 }

--- a/src/main/java/com/forfour/domain/participant/entity/Participant.java
+++ b/src/main/java/com/forfour/domain/participant/entity/Participant.java
@@ -1,6 +1,7 @@
 package com.forfour.domain.participant.entity;
 
 import com.forfour.domain.member.entity.Member;
+import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -25,7 +26,9 @@ public class Participant extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long roomId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId", referencedColumnName = "id")
@@ -34,9 +37,9 @@ public class Participant extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoomStatus roomStatus;
 
-    public static Participant of(Long roomId, Member member) {
+    public static Participant of(Room room, Member member) {
         return Participant.builder()
-                .roomId(roomId)
+                .room(room)
                 .member(member)
                 .roomStatus(RoomStatus.RECRUITING)
                 .build();

--- a/src/main/java/com/forfour/domain/participant/facade/ParticipantFacade.java
+++ b/src/main/java/com/forfour/domain/participant/facade/ParticipantFacade.java
@@ -48,11 +48,11 @@ public class ParticipantFacade {
     public MyParticipationDto checkMyParticipation() {
         Long memberId = MemberContext.getMemberId();
         Participant myProgressParticipation = participantGetService.findMyProgressParticipation(memberId);
-        if(myProgressParticipation == null) {
+        if (myProgressParticipation == null) {
             return MyParticipationDto.from(false, null);
         }
 
-        return MyParticipationDto.from(true, myProgressParticipation.getRoomId());
+        return MyParticipationDto.from(true, myProgressParticipation.getRoom());
     }
 
 }

--- a/src/main/java/com/forfour/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/forfour/domain/participant/repository/ParticipantRepository.java
@@ -2,6 +2,8 @@ package com.forfour.domain.participant.repository;
 
 import com.forfour.domain.participant.entity.Participant;
 import com.forfour.domain.room.entity.RoomStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,10 +17,27 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Participant> findByRoomId(Long roomId);
 
     @Query("SELECT p " +
-            "FROM Participant p JOIN FETCH p.member" +
-            " WHERE p.roomId = :roomId")
+            "FROM Participant p JOIN FETCH p.member " +
+            "WHERE p.room.id = :roomId")
     List<Participant> findParticipantsByRoomId(@Param("roomId") Long roomId);
 
     Optional<Participant> findByMemberIdAndRoomStatus(Long memberId, RoomStatus roomStatus);
+
+    Slice<Participant> findByMemberId(Long memberId, Pageable pageable);
+
+    @Query(value = """
+            select p
+            from Participant p
+            join fetch p.room r
+            join fetch r.leader l
+            where p.member.id = :memberId
+              and p.roomStatus <> :excludedStatus
+            order by r.startAt asc
+            """)
+    Slice<Participant> findMyRoomsWithLeaderExceptStatus(
+            @Param("memberId") Long memberId,
+            @Param("excludedStatus") RoomStatus excludedStatus,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/com/forfour/domain/participant/service/ParticipantGetService.java
+++ b/src/main/java/com/forfour/domain/participant/service/ParticipantGetService.java
@@ -4,6 +4,8 @@ import com.forfour.domain.participant.entity.Participant;
 import com.forfour.domain.participant.repository.ParticipantRepository;
 import com.forfour.domain.room.entity.RoomStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,9 +20,17 @@ public class ParticipantGetService {
         return participantRepository.findParticipantsByRoomId(roomId);
     }
 
+    public Slice<Participant> findMyParticipatingRoom(Long memberId, Pageable pageable) {
+        return participantRepository.findMyRoomsWithLeaderExceptStatus(memberId, RoomStatus.COMPLETED, pageable);
+    }
+
     public Participant findMyProgressParticipation(Long memberId) {
         return participantRepository.findByMemberIdAndRoomStatus(memberId, RoomStatus.PROGRESS)
                 .orElse(null);
+    }
+
+    public Slice<Participant> findMyParticipants(Long memberId, Pageable pageable) {
+        return participantRepository.findByMemberId(memberId, pageable);
     }
 
 }

--- a/src/main/java/com/forfour/domain/participant/service/ParticipantSaveService.java
+++ b/src/main/java/com/forfour/domain/participant/service/ParticipantSaveService.java
@@ -3,6 +3,7 @@ package com.forfour.domain.participant.service;
 import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.participant.entity.Participant;
 import com.forfour.domain.participant.repository.ParticipantRepository;
+import com.forfour.domain.room.entity.Room;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,8 +13,8 @@ public class ParticipantSaveService {
 
     private final ParticipantRepository participantRepository;
 
-    public Participant save(Long roomId, Member member) {
-        return participantRepository.save(Participant.of(roomId, member));
+    public Participant save(Room room, Member member) {
+        return participantRepository.save(Participant.of(room, member));
     }
 
 }

--- a/src/main/java/com/forfour/domain/path/dto/response/PathDetailDto.java
+++ b/src/main/java/com/forfour/domain/path/dto/response/PathDetailDto.java
@@ -8,6 +8,8 @@ public record PathDetailDto(
         Long pathId,
         String pathName,
         double distance,
+        String startMarketName,
+        String endMarketName,
         String startMarketId,
         String endMarketId,
         String pathImageUrl
@@ -17,6 +19,8 @@ public record PathDetailDto(
                 .pathId(path.getId())
                 .pathName(path.getPathName())
                 .distance(path.getDistance())
+                .startMarketName(path.getStartMarketName())
+                .endMarketName(path.getEndMarketName())
                 .startMarketId(path.getStartMarketId().toString())
                 .endMarketId(path.getEndMarketId().toString())
                 .pathImageUrl(path.getPathImageUrl())

--- a/src/main/java/com/forfour/domain/path/entity/Path.java
+++ b/src/main/java/com/forfour/domain/path/entity/Path.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.path.entity;
 
+import com.forfour.domain.market.entity.Market;
 import com.forfour.domain.path.dto.request.PathSaveDto;
 import com.forfour.domain.path.exception.PathException;
 import com.forfour.domain.path.exception.PathExceptionInformation;
@@ -27,6 +28,10 @@ public class Path extends BaseEntity {
 
     private double distance;
 
+    private String startMarketName;
+
+    private String endMarketName;
+
     private UUID startMarketId;
 
     private UUID endMarketId;
@@ -37,6 +42,18 @@ public class Path extends BaseEntity {
         return Path.builder()
                 .pathName(dto.pathName())
                 .distance(dto.distance())
+                .startMarketId(UUID.fromString(dto.startMarketId()))
+                .endMarketId(UUID.fromString(dto.endMarketId()))
+                .pathImageUrl(dto.pathImageUrl())
+                .build();
+    }
+
+    public static Path of(PathSaveDto dto, Market startMarket, Market endMarket) {
+        return Path.builder()
+                .pathName(dto.pathName())
+                .distance(dto.distance())
+                .startMarketName(startMarket.getMarketName())
+                .endMarketName(endMarket.getMarketName())
                 .startMarketId(UUID.fromString(dto.startMarketId()))
                 .endMarketId(UUID.fromString(dto.endMarketId()))
                 .pathImageUrl(dto.pathImageUrl())

--- a/src/main/java/com/forfour/domain/path/facade/PathFacade.java
+++ b/src/main/java/com/forfour/domain/path/facade/PathFacade.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.path.facade;
 
+import com.forfour.domain.market.entity.Market;
 import com.forfour.domain.market.service.MarketGetService;
 import com.forfour.domain.path.dto.request.PathSaveDto;
 import com.forfour.domain.path.dto.response.PathDetailDto;
@@ -22,10 +23,10 @@ public class PathFacade {
     private final MarketGetService marketGetService;
 
     public PathDetailDto save(PathSaveDto dto) {
-        marketGetService.validateMarket(dto.startMarketId());
-        marketGetService.validateMarket(dto.endMarketId());
+        Market startMarket = marketGetService.getMarketById(dto.startMarketId());
+        Market endMarket = marketGetService.getMarketById(dto.endMarketId());
 
-        Path saved = pathSaveService.save(dto);
+        Path saved = pathSaveService.save(dto, startMarket, endMarket);
         return PathDetailDto.from(saved);
     }
 

--- a/src/main/java/com/forfour/domain/path/service/PathSaveService.java
+++ b/src/main/java/com/forfour/domain/path/service/PathSaveService.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.path.service;
 
+import com.forfour.domain.market.entity.Market;
 import com.forfour.domain.path.dto.request.PathSaveDto;
 import com.forfour.domain.path.entity.Path;
 import com.forfour.domain.path.repository.PathRepository;
@@ -12,7 +13,7 @@ public class PathSaveService {
 
     private final PathRepository pathRepository;
 
-    public Path save(PathSaveDto dto) {
-        return pathRepository.save(Path.from(dto));
+    public Path save(PathSaveDto dto, Market startMarket, Market endMarket) {
+        return pathRepository.save(Path.of(dto, startMarket, endMarket));
     }
 }

--- a/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
+++ b/src/main/java/com/forfour/domain/room/controller/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
     ROOM_PARTICIPANT("[산책 방]에 참여했습니다."),
     ROOM_SCROLL_LIST_READ("[산책 방]에 목록을 조회합니다."),
     ROOM_READ("[산책 방 + 참여자 정보]를 조회합니다."),
+    ROOM_MY_READ("내가 참여한 [산책 방 + 참여자 정보]를 조회합니다."),
     ROOM_RECRUIT_STATUS_UPDATED("[산책방 모집 상태]를 변경합니다."),
     WALKING_START("[산책]을 시작합니다."),
     WALKING_END("[산책]을 종료합니다."),

--- a/src/main/java/com/forfour/domain/room/controller/RoomController.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomController.java
@@ -54,6 +54,16 @@ public class RoomController implements RoomSwagger{
     }
 
     @AuthGuard({MemberGuard.class, AdminGuard.class})
+    @GetMapping("/v1/my-room")
+    public ApiResponse<SliceRoomDto> readMyRoom(
+            @RequestParam int pageSize,
+            @RequestParam int pageNum
+    ) {
+        SliceRoomDto response = facade.readMyRoom(pageSize, pageNum);
+        return ApiResponse.response(HttpStatus.OK, ROOM_MY_READ.getMeesage() , response);
+    }
+
+    @AuthGuard({MemberGuard.class, AdminGuard.class})
     @GetMapping("/v1/room-list")
     public ApiResponse<SliceRoomDto> scrollRoom(
             @RequestParam int pageSize,

--- a/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
+++ b/src/main/java/com/forfour/domain/room/controller/RoomSwagger.java
@@ -15,10 +15,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "산책 방")
 public interface RoomSwagger {
@@ -31,6 +28,9 @@ public interface RoomSwagger {
 
     @Operation(description = "[산책 방 + 참여자 정보] 조회 API", summary = "[산책 방 + 참여자 정보] 조회 API")
     ApiResponse<RoomWithParticipantsDto> readRoom(@PathVariable Long roomId);
+
+    @Operation(description = "내가 참여한 산책방 정보 조회 API", summary = "내가 참여한 산책방 정보 조회 API")
+    ApiResponse<SliceRoomDto> readMyRoom(@RequestParam int pageSize, @RequestParam int pageNum);
 
     @Operation(description = "산책 방 목록 조회 API", summary = "산책 방 목록 조회 API")
     ApiResponse<SliceRoomDto> scrollRoom(

--- a/src/main/java/com/forfour/domain/room/dto/response/RoomDetailDto.java
+++ b/src/main/java/com/forfour/domain/room/dto/response/RoomDetailDto.java
@@ -14,6 +14,8 @@ public record RoomDetailDto(
         Long leaderId,
         String leaderName,
         Long pathId,
+        String startMarketName,
+        String endMarketName,
         String missionName,
         int maxMemberCount,
         int memberCount,
@@ -27,6 +29,8 @@ public record RoomDetailDto(
                 .leaderId(leader.getId())
                 .leaderName(leader.getNickname())
                 .pathId(room.getPathId())
+                .startMarketName(room.getStartMarketName())
+                .endMarketName(room.getEndMarketName())
                 .missionName(room.getMission().name())
                 .maxMemberCount(room.getMaxMemberCount())
                 .memberCount(room.getMemberCount())
@@ -42,6 +46,8 @@ public record RoomDetailDto(
                 .leaderId(room.getLeader().getId())
                 .leaderName(room.getLeader().getNickname())
                 .pathId(room.getPathId())
+                .startMarketName(room.getStartMarketName())
+                .endMarketName(room.getEndMarketName())
                 .missionName(room.getMission().name())
                 .status(room.getStatus())
                 .startAt(room.getStartAt())

--- a/src/main/java/com/forfour/domain/room/dto/response/RoomDetailDto.java
+++ b/src/main/java/com/forfour/domain/room/dto/response/RoomDetailDto.java
@@ -49,6 +49,8 @@ public record RoomDetailDto(
                 .startMarketName(room.getStartMarketName())
                 .endMarketName(room.getEndMarketName())
                 .missionName(room.getMission().name())
+                .maxMemberCount(room.getMaxMemberCount())
+                .memberCount(room.getMemberCount())
                 .status(room.getStatus())
                 .startAt(room.getStartAt())
                 .build();

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -1,6 +1,7 @@
 package com.forfour.domain.room.entity;
 
 import com.forfour.domain.member.entity.Member;
+import com.forfour.domain.path.entity.Path;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.exception.*;
 import com.forfour.global.common.entity.BaseEntity;
@@ -31,7 +32,13 @@ public class Room extends BaseEntity {
     @JoinColumn(name = "leaderId", referencedColumnName = "id")
     private Member leader;
 
+    private String leaderName;
+
     private Long pathId;
+
+    private String startMarketName;
+
+    private String endMarketName;
 
     private Mission mission;
 
@@ -50,11 +57,14 @@ public class Room extends BaseEntity {
 
     private LocalDateTime stopwatchEndAt;
 
-    public static Room of(RoomSaveDto dto, Member leader) {
+    public static Room of(RoomSaveDto dto, Member leader, Path path) {
         return Room.builder()
                 .title(dto.title())
                 .leader(leader)
+                .leaderName(leader.getNickname())
                 .pathId(dto.pathId())
+                .startMarketName(path.getStartMarketName())
+                .endMarketName(path.getEndMarketName())
                 .mission(Mission.value(dto.missionName()))
                 .maxMemberCount(dto.maxMemberCount())
                 .memberCount(1)

--- a/src/main/java/com/forfour/domain/room/entity/Room.java
+++ b/src/main/java/com/forfour/domain/room/entity/Room.java
@@ -118,6 +118,10 @@ public class Room extends BaseEntity {
         this.status = status;
     }
 
+    public void updateLeaderName(String leaderName) {
+        this.leaderName = leaderName;
+    }
+
     public void validateMinimumMember() {
         if (this.memberCount < MINIMUM_MEMBER_COUNT) {
             throw new RoomException(RoomExceptionInformation.ROOM_NOT_ENOUGH_MINIMUM_MEMBER);

--- a/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.room.repository;
 
+import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.entity.RoomStatus;
 import jakarta.persistence.LockModeType;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,5 +35,9 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     Slice<Room> findActiveRooms(
             Pageable pageable
     );
+
+    List<Room> findByLeader(Member leader);
+
+    List<Room> findByLeaderAndStatusNot(Member leader, RoomStatus status);
 
 }

--- a/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/forfour/domain/room/repository/RoomRepository.java
@@ -34,5 +34,4 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
             Pageable pageable
     );
 
-
 }

--- a/src/main/java/com/forfour/domain/room/service/RoomGetService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomGetService.java
@@ -1,5 +1,6 @@
 package com.forfour.domain.room.service;
 
+import com.forfour.domain.member.entity.Member;
 import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.entity.RoomStatus;
 import com.forfour.domain.room.exception.RoomException;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -35,6 +37,14 @@ public class RoomGetService {
 
     public Slice<Room> getActiveRoomsWithStatus(RoomStatus status, Pageable pageable) {
         return roomRepository.findActiveRoomsWithStatus(status, pageable);
+    }
+
+    public List<Room> findByLeader(Member leader) {
+        return roomRepository.findByLeader(leader);
+    }
+
+    public List<Room> findByLeaderAndStatusNot(Member leader) {
+        return roomRepository.findByLeaderAndStatusNot(leader, RoomStatus.COMPLETED);
     }
 
 }

--- a/src/main/java/com/forfour/domain/room/service/RoomSaveService.java
+++ b/src/main/java/com/forfour/domain/room/service/RoomSaveService.java
@@ -1,6 +1,7 @@
 package com.forfour.domain.room.service;
 
 import com.forfour.domain.member.entity.Member;
+import com.forfour.domain.path.entity.Path;
 import com.forfour.domain.room.dto.request.RoomSaveDto;
 import com.forfour.domain.room.entity.Room;
 import com.forfour.domain.room.repository.RoomRepository;
@@ -13,8 +14,8 @@ public class RoomSaveService {
 
     private final RoomRepository roomRepository;
 
-    public Room save(RoomSaveDto dto, Member leader) {
-        return roomRepository.save(Room.of(dto, leader));
+    public Room save(RoomSaveDto dto, Member leader, Path path) {
+        return roomRepository.save(Room.of(dto, leader, path));
     }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

내가 참여한 산책방 리스트 조회 API 구현

잦은 Join으로 인해 성능 저하를 우려 -> 엔티티 구조 개선

- Path에 marketName을 추가 (Market Name은 한번 정해지고 잘 변경되지 않으므로.)
- Room에 leaderName 추가. 단, 닉네임 수정 시, 내가 방장이고 산책종료가 아닌 Room을 찾아서 함께 update
   - 조회 성능을 높이는 대신, 닉네임 수정 성능을 떨어트리는 Trade Off


## 📎 Issue #번호
<!-- closed #번호 -->